### PR TITLE
Fix three of a kind 2 test

### DIFF
--- a/holdem/app/src/main/java/com/fanzengau/holdem/ShowDown.java
+++ b/holdem/app/src/main/java/com/fanzengau/holdem/ShowDown.java
@@ -103,8 +103,9 @@ class ShowDown {
                     kickers[0] = new Card(countResult.maxCountRank);
                     int count = 1;
                     for (int i = 14; i > 0; i--) {
-                        if (countResult.rankCount[i % 13] >= 1 && i != countResult.maxCountRank) {
-                            kickers[count] = new Card(i + 52);
+                        if (countResult.rankCount[i % 13] >= 1 && i % 13 != countResult.maxCountRank) {
+                            kickers[count] = new Card(i + 52); // add 52 to get a spade card as kicker, since suit is
+                                                               // unimportant.
                             count++;
                             if (count == 3)
                                 break;

--- a/holdem/app/src/test/java/com/fanzengau/holdem/ShowDownTest.java
+++ b/holdem/app/src/test/java/com/fanzengau/holdem/ShowDownTest.java
@@ -128,17 +128,17 @@ class ShowDownTest {
         testShowDownResult(privateCards, board, expectedBestHandType, expectedKickers);
     }
 
-    // @Test
-    // void getShowDownResultThreeOfAKind2() {
-    // var privateCards = new String[]{"5C", "4C"};
-    // var board = new String[]{"2C", "3S", "KS", "KH", "KD"};
-    // var expectedBestHandType = THREE_OF_A_KIND;
-    // var expectedKickers = new Card[]{
-    // new Card("KS"), new Card("5*"), new Card("4*")
-    // };
-    // testShowDownResult(privateCards, board, expectedBestHandType,
-    // expectedKickers);
-    // }
+    @Test
+    void getShowDownResultThreeOfAKind2() {
+        var privateCards = new String[] { "5C", "4C" };
+        var board = new String[] { "2C", "3S", "KS", "KH", "KD" };
+        var expectedBestHandType = THREE_OF_A_KIND;
+        var expectedKickers = new Card[] {
+                new Card("KS"), new Card("5*"), new Card("4*")
+        };
+        testShowDownResult(privateCards, board, expectedBestHandType,
+                expectedKickers);
+    }
 
     @Test
     void getShowDownResultTwoPair() {


### PR DESCRIPTION
- Re-enabled the commented-out test.
- Found the issue of missing modulo. The card ranks in the relevant code has "King" mapped to rank 0 and "Ace" mapped to rank 1.